### PR TITLE
refactor tasks layer to follow clean architecture

### DIFF
--- a/src/prisma/tasks.repository.ts
+++ b/src/prisma/tasks.repository.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+import { Task } from 'src/tasks/entities/task.entity';
+import { TasksRepository } from 'src/tasks/tasks.repository';
+
+@Injectable()
+export class PrismaTasksRepository implements TasksRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findAll(params: { limit: number; offset: number }): Promise<Task[]> {
+    const { limit, offset } = params;
+    return this.prisma.task.findMany({
+      take: limit,
+      skip: offset,
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  findById(id: string): Promise<Task | null> {
+    return this.prisma.task.findFirst({ where: { id } });
+  }
+
+  create(data: {
+    name: string;
+    description: string;
+    completed: boolean;
+    userId: string;
+  }): Promise<Task> {
+    return this.prisma.task.create({
+      data: {
+        name: data.name,
+        description: data.description,
+        completed: data.completed,
+        userId: data.userId,
+      },
+    });
+  }
+
+  update(
+    id: string,
+    data: Partial<{ name: string; description: string; completed: boolean }>,
+  ): Promise<Task> {
+    return this.prisma.task.update({
+      where: { id },
+      data,
+    });
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.task.delete({ where: { id } });
+  }
+}
+

--- a/src/tasks/entities/task.entity.ts
+++ b/src/tasks/entities/task.entity.ts
@@ -3,5 +3,6 @@ export class Task {
   name: string;
   description: string;
   completed: boolean;
+  userId: string;
   createdAt?: Date;
 }

--- a/src/tasks/tasks.module.ts
+++ b/src/tasks/tasks.module.ts
@@ -5,6 +5,8 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { APP_FILTER } from '@nestjs/core';
 import { ApiExceptionFilter } from 'src/common/filters/exception-filter';
 import { TaskUtils } from './tasks.utils';
+import { PrismaTasksRepository } from '../prisma/tasks.repository';
+import { TASKS_REPOSITORY } from './tasks.repository';
 
 @Module({
   imports: [PrismaModule],
@@ -12,6 +14,10 @@ import { TaskUtils } from './tasks.utils';
   providers: [
     TasksService,
     TaskUtils,
+    {
+      provide: TASKS_REPOSITORY,
+      useClass: PrismaTasksRepository,
+    },
     {
       provide: APP_FILTER,
       useClass: ApiExceptionFilter,

--- a/src/tasks/tasks.repository.ts
+++ b/src/tasks/tasks.repository.ts
@@ -1,0 +1,20 @@
+import { Task } from './entities/task.entity';
+
+export interface TasksRepository {
+  findAll(params: { limit: number; offset: number }): Promise<Task[]>;
+  findById(id: string): Promise<Task | null>;
+  create(data: {
+    name: string;
+    description: string;
+    completed: boolean;
+    userId: string;
+  }): Promise<Task>;
+  update(
+    id: string,
+    data: Partial<{ name: string; description: string; completed: boolean }>,
+  ): Promise<Task>;
+  delete(id: string): Promise<void>;
+}
+
+export const TASKS_REPOSITORY = 'TasksRepository';
+

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -1,35 +1,30 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
-import { PrismaService } from '../prisma/prisma.service';
 import { PaginationDto } from 'src/common/dto/pagination.dto';
 import { PayloadTokenDto } from 'src/auth/dto/payload-token.dto';
 import { ResponseTaskDto } from './dto/response-task.dto';
+import { TasksRepository, TASKS_REPOSITORY } from './tasks.repository';
 
 @Injectable()
 export class TasksService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    @Inject(TASKS_REPOSITORY) private readonly tasksRepository: TasksRepository,
+  ) {}
 
   async findAll(paginationDto?: PaginationDto): Promise<ResponseTaskDto[]> {
     const { limit = 10, offset = 0 } = paginationDto ?? {};
 
-    const allTasks = await this.prisma.task.findMany({
-      take: limit,
-      skip: offset,
-      orderBy: {
-        createdAt: 'desc',
-      },
+    const allTasks = await this.tasksRepository.findAll({
+      limit,
+      offset,
     });
 
     return allTasks;
   }
 
   async findOne(id: string): Promise<ResponseTaskDto> {
-    const task = await this.prisma.task.findFirst({
-      where: {
-        id: id,
-      },
-    });
+    const task = await this.tasksRepository.findById(id);
 
     if (task?.name) return task;
 
@@ -44,13 +39,11 @@ export class TasksService {
     tokenPayload: PayloadTokenDto,
   ): Promise<ResponseTaskDto> {
     try {
-      const newTask = await this.prisma.task.create({
-        data: {
-          name: createTaskDto.name,
-          description: createTaskDto.description,
-          completed: false,
-          userId: tokenPayload.sub,
-        },
+      const newTask = await this.tasksRepository.create({
+        name: createTaskDto.name,
+        description: createTaskDto.description,
+        completed: false,
+        userId: tokenPayload.sub,
       });
 
       return newTask;
@@ -69,11 +62,7 @@ export class TasksService {
     tokenPayload: PayloadTokenDto,
   ): Promise<ResponseTaskDto> {
     try {
-      const findTask = await this.prisma.task.findFirst({
-        where: {
-          id: id,
-        },
-      });
+      const findTask = await this.tasksRepository.findById(id);
 
       if (!findTask) {
         throw new HttpException(
@@ -89,19 +78,14 @@ export class TasksService {
         );
       }
 
-      const task = await this.prisma.task.update({
-        where: {
-          id: findTask.id,
-        },
-        data: {
-          name: updateTaskDto?.name ? updateTaskDto?.name : findTask.name,
-          description: updateTaskDto?.description
-            ? updateTaskDto?.description
-            : findTask.description,
-          completed: updateTaskDto?.completed
-            ? updateTaskDto?.completed
-            : findTask.completed,
-        },
+      const task = await this.tasksRepository.update(findTask.id, {
+        name: updateTaskDto?.name ? updateTaskDto?.name : findTask.name,
+        description: updateTaskDto?.description
+          ? updateTaskDto?.description
+          : findTask.description,
+        completed: updateTaskDto?.completed
+          ? updateTaskDto?.completed
+          : findTask.completed,
       });
 
       return task;
@@ -115,11 +99,7 @@ export class TasksService {
 
   async delete(id: string, tokenPayload: PayloadTokenDto) {
     try {
-      const findTask = await this.prisma.task.findFirst({
-        where: {
-          id: id,
-        },
-      });
+      const findTask = await this.tasksRepository.findById(id);
 
       if (!findTask) {
         throw new HttpException(
@@ -135,11 +115,7 @@ export class TasksService {
         );
       }
 
-      await this.prisma.task.delete({
-        where: {
-          id: findTask.id,
-        },
-      });
+      await this.tasksRepository.delete(findTask.id);
 
       return {
         message: 'Tarefa deletada com sucesso!',


### PR DESCRIPTION
## Summary
- add repository interface and Prisma implementation for tasks
- decouple task service from Prisma
- wire repository provider in tasks module

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68913fed5964832780a8908ee3e9770e